### PR TITLE
docs(codesign): add alternative instructions using Xcode auto-sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Tested with Mail for macOS Big Sur.
 codesign -s "<Replace with the identity>" -v -f GMailinator.mailbundle/
 ```
 
+Alternatively, you can enable "Automatically manage signing" in Xcode:
+- Under the "Signing and Capabilities" tab (find this by clicking GMailinator root in sidebar)
+- Check "Automatically manage signing"
+- Change "Team" dropdown. You'll need to do some setup if you don't have a team
+- Now mail bundle will automatically be signed on Xcode build
+
+
 - Allow in system policy
 ```
 spctl --add ~/Library/Mail/Bundles/GMailinator.mailbundle


### PR DESCRIPTION
Hi @wwwjfy thank you for maintaining this repo, especially with each macOS breaking change! Really appreciate you keeping it up to date through the years. GMail bindings is the only thing that keeps me using Apple Mail.

I recently upgraded to Big Sur, and naturally that broke GMailinator again. I followed your updated Big Sur instructions which worked great, and thought I'd add some more details for doing the `codesign` step -- specifically you can instead have XCode manage signing for you.