### PR TITLE
Fix build errors and warnings

### DIFF
--- a/GMailinator/GMailinator.m
+++ b/GMailinator/GMailinator.m
@@ -36,9 +36,9 @@ SearchManager *_sm;
  * they common keyDown:.
  */
 + (void)setupClass:(Class)cls swappingKeyDownWith:(SEL)overrideSelector {
-    if (DEBUG) {
+    #ifdef DEBUG
         [self logAllSelectorsFromClass:cls];
-    }
+    #endif
 
     if (cls == nil)
         return;

--- a/GMailinator/GMailinator.m
+++ b/GMailinator/GMailinator.m
@@ -101,6 +101,8 @@ SearchManager *_sm;
     unichar key = [[event characters] characterAtIndex:0];
     BOOL performed = YES;
 
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wundeclared-selector"
     switch (key) {
     case '#': {
         [messageViewer performSelector:@selector(deleteMessages:)
@@ -160,6 +162,7 @@ SearchManager *_sm;
     default:
         performed = NO;
     }
+    #pragma clang diagnostic pop
     return performed;
 }
 
@@ -259,11 +262,14 @@ SearchManager *_sm;
 
     // NOTE: backwards compatibility. In 10.11 and earlier,
     // tableViewManager.delegate.delegate was already the message viewer.
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wundeclared-selector"
     id messageViewer =
         [messageListViewController respondsToSelector:@selector(messageViewer)]
             ? [messageListViewController
                   performSelector:@selector(messageViewer)]
             : messageListViewController;
+    #pragma clang diagnostic pop
 
     if (![self performSelectorOnMessageViewer:messageViewer
                                  basedOnEvent:event]) {

--- a/GMailinator/SearchPopup.m
+++ b/GMailinator/SearchPopup.m
@@ -57,6 +57,8 @@
     // update menu items
     [[submenu delegate] menuNeedsUpdate:submenu];
 
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wundeclared-selector"
     // set message handling to copy / move
     if ([submenu respondsToSelector:@selector
                  (_sendMenuOpeningNotification:)]) { // Yosemite 10.10.2
@@ -65,6 +67,7 @@
                         (_sendMenuOpeningNotification)]) {
         [submenu performSelector:@selector(_sendMenuOpeningNotification)];
     }
+    #pragma clang diagnostic pop
 
     //	if ([p lastFolder] != nil)
     //    {


### PR DESCRIPTION
This PR has a couple of minor patches to fix errors and warnings on recent versions of Xcode. I’ve tested this with Xcode 14.3 on Intel.

The build error is this:

```
/Users/jason/projects/GMailinator/GMailinator/GMailinator.m:39:9: error: use of undeclared identifier 'DEBUG'
    if (DEBUG) {
        ^
```

which I have switched to be an `#ifdef`.

The warnings are undefined selectors:

```
/Users/jason/projects/GMailinator/GMailinator/GMailinator.m:106:41: warning: undeclared selector 'deleteMessages:'
      [-Wundeclared-selector]
        [messageViewer performSelector:@selector(deleteMessages:)
```

which makes sense since we’re calling into private APIs.

With both of these patches the build is clean.